### PR TITLE
Add Disabled Status to Old Time Slots.

### DIFF
--- a/__tests__/Day.react-test.js
+++ b/__tests__/Day.react-test.js
@@ -18,7 +18,7 @@ describe('Render tests', () => {
         timeslots = { DEFAULT_TIMESLOTS }
         onTimeslotClick = { onClickSpy }
         momentTime = { moment([2017, 3, 28]) }
-        initialDate = { moment([2017, 3, 28]).format() }
+        initialDate = { moment([2017, 3, 28]) }
       />
     )
     .toJSON();
@@ -29,9 +29,9 @@ describe('Render tests', () => {
   test('Renders Correctly if timeslots is an array of strings.', () => {
     const onClickSpy = sinon.spy();
     const timeslots = [
-      'now',
-      'then',
-      'later',
+      '0',
+      '1',
+      '2',
     ];
 
     const tree = renderer.create(
@@ -39,7 +39,7 @@ describe('Render tests', () => {
         timeslots = { timeslots }
         onTimeslotClick = { onClickSpy }
         momentTime = { moment([2017, 3, 28]) }
-        initialDate = { moment([2017, 3, 28]).format() }
+        initialDate = { moment([2017, 3, 28]) }
       />
     )
     .toJSON();
@@ -50,9 +50,9 @@ describe('Render tests', () => {
   test('Renders Correctly if timeslots is an array of array.', () => {
     const onClickSpy = sinon.spy();
     const timeslots = [
-      ['now', 'then', 'later'],
-      ['then', 'later'],
-      'later',
+      ['0', '1'],
+      ['1', '2'],
+      '3',
     ];
 
     const tree = renderer.create(
@@ -60,7 +60,7 @@ describe('Render tests', () => {
       timeslots = { timeslots }
       onTimeslotClick = { onClickSpy }
       momentTime = { moment([2017, 3, 28]) }
-      initialDate = { moment([2017, 3, 28]).format() }
+      initialDate = { moment([2017, 3, 28]) }
       />
     )
     .toJSON();
@@ -79,8 +79,7 @@ describe('Functionality tests', () => {
         onTimeslotClick = { onClickSpy }
         renderTitle = { renderTitleSpy }
         momentTime = { moment([2017, 3, 28]) }
-        initialDate = { moment([2017, 3, 28]).format() }
-
+        initialDate = { moment([2017, 3, 28]) }
       />
     );
 
@@ -94,7 +93,7 @@ describe('Functionality tests', () => {
         timeslots = { DEFAULT_TIMESLOTS }
         onTimeslotClick = { onClickSpy }
         momentTime = { moment([2017, 3, 28]) }
-        initialDate = { moment([2017, 3, 27]).format() }
+        initialDate = { moment([2017, 3, 27]) }
       />
     );
 
@@ -111,7 +110,7 @@ describe('Functionality tests', () => {
         timeslots = { DEFAULT_TIMESLOTS }
         onTimeslotClick = { onClickSpy }
         momentTime = { moment([2017, 3, 28]) }
-        initialDate = { moment([2017, 1, 1]).format() }
+        initialDate = { moment([2017, 1, 1]) }
       />
     );
 
@@ -123,15 +122,15 @@ describe('Functionality tests', () => {
   test('Renders only the amount of timeslots provided', () => {
     const onClickSpy = sinon.spy();
     const timeslots = [
-      ['Start', 'End'],
-      ['Start 2', 'End 2'],
+      ['0', '1'],
+      ['1', '2'],
     ];
     const component = shallow(
       <Day
         timeslots = { timeslots }
         onTimeslotClick = { onClickSpy }
         momentTime = { moment([2017, 3, 28]) }
-        initialDate = { moment([2017, 3, 28]).format() }
+        initialDate = { moment([2017, 3, 28]) }
       />
     );
 
@@ -147,7 +146,7 @@ describe('Functionality tests', () => {
         timeslots = { DEFAULT_TIMESLOTS }
         onTimeslotClick = { onClickSpy }
         momentTime = { moment([2017, 3, 28]) }
-        initialDate = { moment([2017, 3, 28, 11]).format() }
+        initialDate = { moment([2017, 3, 28, 11]) }
       />
     );
 

--- a/__tests__/Day.react-test.js
+++ b/__tests__/Day.react-test.js
@@ -16,8 +16,9 @@ describe('Render tests', () => {
     const tree = renderer.create(
       <Day
         timeslots = { DEFAULT_TIMESLOTS }
-      onTimeslotClick = { onClickSpy }
-      momentTime = { moment([2017, 3, 28]) }
+        onTimeslotClick = { onClickSpy }
+        momentTime = { moment([2017, 3, 28]) }
+        initialDate = { moment([2017, 3, 28]).format() }
       />
     )
     .toJSON();
@@ -35,10 +36,10 @@ describe('Render tests', () => {
 
     const tree = renderer.create(
       <Day
-        timeslots = { DEFAULT_TIMESLOTS }
-      onTimeslotClick = { onClickSpy }
-      momentTime = { moment([2017, 3, 28]) }
-      timeslots = { timeslots }
+        timeslots = { timeslots }
+        onTimeslotClick = { onClickSpy }
+        momentTime = { moment([2017, 3, 28]) }
+        initialDate = { moment([2017, 3, 28]).format() }
       />
     )
     .toJSON();
@@ -56,10 +57,10 @@ describe('Render tests', () => {
 
     const tree = renderer.create(
       <Day
-        timeslots = { DEFAULT_TIMESLOTS }
+      timeslots = { timeslots }
       onTimeslotClick = { onClickSpy }
       momentTime = { moment([2017, 3, 28]) }
-      timeslots = { timeslots }
+      initialDate = { moment([2017, 3, 28]).format() }
       />
     )
     .toJSON();
@@ -78,6 +79,8 @@ describe('Functionality tests', () => {
         onTimeslotClick = { onClickSpy }
         renderTitle = { renderTitleSpy }
         momentTime = { moment([2017, 3, 28]) }
+        initialDate = { moment([2017, 3, 28]).format() }
+
       />
     );
 
@@ -91,10 +94,11 @@ describe('Functionality tests', () => {
         timeslots = { DEFAULT_TIMESLOTS }
         onTimeslotClick = { onClickSpy }
         momentTime = { moment([2017, 3, 28]) }
+        initialDate = { moment([2017, 3, 27]).format() }
       />
     );
 
-    const timeslot = component.find(Timeslot).first();
+    const timeslot = component.find(Timeslot).not('.tsc-timeslot--disabled').first();
     timeslot.simulate('click');
 
     expect(onClickSpy).toHaveProperty('callCount', 1);
@@ -107,6 +111,7 @@ describe('Functionality tests', () => {
         timeslots = { DEFAULT_TIMESLOTS }
         onTimeslotClick = { onClickSpy }
         momentTime = { moment([2017, 3, 28]) }
+        initialDate = { moment([2017, 1, 1]).format() }
       />
     );
 
@@ -123,16 +128,32 @@ describe('Functionality tests', () => {
     ];
     const component = shallow(
       <Day
-        timeslots = { DEFAULT_TIMESLOTS }
+        timeslots = { timeslots }
         onTimeslotClick = { onClickSpy }
         momentTime = { moment([2017, 3, 28]) }
-        timeslots = { timeslots }
+        initialDate = { moment([2017, 3, 28]).format() }
       />
     );
 
     const timeslot = component.find(Timeslot);
 
     expect(timeslot).toHaveLength(2);
+  });
+
+  test('Expect 12 disabled timeslots', () => {
+    const onClickSpy = sinon.spy();
+    const component = mount(
+      <Day
+        timeslots = { DEFAULT_TIMESLOTS }
+        onTimeslotClick = { onClickSpy }
+        momentTime = { moment([2017, 3, 28]) }
+        initialDate = { moment([2017, 3, 28, 11]).format() }
+      />
+    );
+
+    const timeslot = component.find('.tsc-timeslot--disabled');
+
+    expect(timeslot).toHaveLength(12);
   });
 
 });

--- a/__tests__/Month.react-test.js
+++ b/__tests__/Month.react-test.js
@@ -20,7 +20,7 @@ describe('Render tests', () => {
         timeslots = { DEFAULT_TIMESLOTS }
         weeks = { weeks }
         currentDate = { moment([2017, 3, 1]) }
-        initialDate = { moment([2017, 3, 28]).format() }
+        initialDate = { moment([2017, 3, 28]) }
       />
     )
     .toJSON();
@@ -36,7 +36,7 @@ describe('Render tests', () => {
         timeslots = { DEFAULT_TIMESLOTS }
         weeks = { weeks }
         currentDate = { moment([2017, 3, 1]) }
-        initialDate = { moment([2017, 3, 28]).format() }
+        initialDate = { moment([2017, 3, 28]) }
         onWeekOutOfMonth = { onWeekOutOfMonth }
       />
     )
@@ -55,8 +55,7 @@ describe('Functionality tests', () => {
         timeslots = { DEFAULT_TIMESLOTS }
         weeks = { weeks }
         currentDate = { currentDate }
-        initialDate = { moment([2017, 3, 28]).format() }
-
+        initialDate = { moment([2017, 3, 28]) }
       />
     );
 
@@ -85,7 +84,7 @@ describe('Functionality tests', () => {
         timeslots = { DEFAULT_TIMESLOTS }
         weeks = { weeks }
         currentDate = { currentDate }
-        initialDate = { moment([2017, 3, 28]).format() }
+        initialDate = { moment([2017, 3, 28]) }
         onWeekOutOfMonth = { onWeekOutOfMonth }
       />
     );
@@ -103,7 +102,7 @@ describe('Functionality tests', () => {
         timeslots = { DEFAULT_TIMESLOTS }
         weeks = { weeks }
         currentDate = { currentDate }
-        initialDate = { moment([2017, 3, 28]).format() }
+        initialDate = { moment([2017, 3, 28]) }
         onWeekOutOfMonth = { onWeekOutOfMonth }
       />
     );
@@ -120,7 +119,7 @@ describe('Functionality tests', () => {
         timeslots = { DEFAULT_TIMESLOTS }
         weeks = { weeks }
         currentDate = { currentDate }
-        initialDate = { moment([2017, 3, 28]).format() }
+        initialDate = { moment([2017, 3, 28]) }
       />
     );
     const weekIndexBeforeClick = component.state().currentWeekIndex;
@@ -137,7 +136,7 @@ describe('Functionality tests', () => {
         timeslots = { DEFAULT_TIMESLOTS }
         weeks = { weeks }
         currentDate = { currentDate }
-        initialDate = { moment([2017, 3, 28]).format() }
+        initialDate = { moment([2017, 3, 28]) }
       />
     );
 

--- a/__tests__/Month.react-test.js
+++ b/__tests__/Month.react-test.js
@@ -20,6 +20,7 @@ describe('Render tests', () => {
         timeslots = { DEFAULT_TIMESLOTS }
         weeks = { weeks }
         currentDate = { moment([2017, 3, 1]) }
+        initialDate = { moment([2017, 3, 28]).format() }
       />
     )
     .toJSON();
@@ -35,6 +36,7 @@ describe('Render tests', () => {
         timeslots = { DEFAULT_TIMESLOTS }
         weeks = { weeks }
         currentDate = { moment([2017, 3, 1]) }
+        initialDate = { moment([2017, 3, 28]).format() }
         onWeekOutOfMonth = { onWeekOutOfMonth }
       />
     )
@@ -53,6 +55,8 @@ describe('Functionality tests', () => {
         timeslots = { DEFAULT_TIMESLOTS }
         weeks = { weeks }
         currentDate = { currentDate }
+        initialDate = { moment([2017, 3, 28]).format() }
+
       />
     );
 
@@ -81,6 +85,7 @@ describe('Functionality tests', () => {
         timeslots = { DEFAULT_TIMESLOTS }
         weeks = { weeks }
         currentDate = { currentDate }
+        initialDate = { moment([2017, 3, 28]).format() }
         onWeekOutOfMonth = { onWeekOutOfMonth }
       />
     );
@@ -98,6 +103,7 @@ describe('Functionality tests', () => {
         timeslots = { DEFAULT_TIMESLOTS }
         weeks = { weeks }
         currentDate = { currentDate }
+        initialDate = { moment([2017, 3, 28]).format() }
         onWeekOutOfMonth = { onWeekOutOfMonth }
       />
     );
@@ -114,6 +120,7 @@ describe('Functionality tests', () => {
         timeslots = { DEFAULT_TIMESLOTS }
         weeks = { weeks }
         currentDate = { currentDate }
+        initialDate = { moment([2017, 3, 28]).format() }
       />
     );
     const weekIndexBeforeClick = component.state().currentWeekIndex;
@@ -130,6 +137,7 @@ describe('Functionality tests', () => {
         timeslots = { DEFAULT_TIMESLOTS }
         weeks = { weeks }
         currentDate = { currentDate }
+        initialDate = { moment([2017, 3, 28]).format() }
       />
     );
 

--- a/__tests__/Week.react-test.js
+++ b/__tests__/Week.react-test.js
@@ -26,7 +26,7 @@ describe('Render tests', () => {
         timeslots = { DEFAULT_TIMESLOTS }
         weekToRender = { weeks[0] }
         onTimeslotClick = { onClickSpy }
-        initialDate = { moment([2017, 3, 28]).format() }
+        initialDate = { moment([2017, 3, 28]) }
       />
     )
     .toJSON();
@@ -43,7 +43,7 @@ describe('Render tests', () => {
         timeslots = { DEFAULT_TIMESLOTS }
         weekToRender = { weeks[0].slice(0, 3) }
         onTimeslotClick = { onClickSpy }
-        initialDate = { moment([2017, 3, 28]).format() }
+        initialDate = { moment([2017, 3, 28]) }
       />
     );
 
@@ -61,7 +61,7 @@ describe('Render tests', () => {
         timeslots = { DEFAULT_TIMESLOTS }
         weekToRender = { weeks[0] }
         onTimeslotClick = { onClickSpy }
-        initialDate = { moment([2017, 1, 1]).format() }
+        initialDate = { moment([2017, 1, 1]) }
       />
     );
 

--- a/__tests__/Week.react-test.js
+++ b/__tests__/Week.react-test.js
@@ -26,6 +26,7 @@ describe('Render tests', () => {
         timeslots = { DEFAULT_TIMESLOTS }
         weekToRender = { weeks[0] }
         onTimeslotClick = { onClickSpy }
+        initialDate = { moment([2017, 3, 28]).format() }
       />
     )
     .toJSON();
@@ -42,6 +43,7 @@ describe('Render tests', () => {
         timeslots = { DEFAULT_TIMESLOTS }
         weekToRender = { weeks[0].slice(0, 3) }
         onTimeslotClick = { onClickSpy }
+        initialDate = { moment([2017, 3, 28]).format() }
       />
     );
 
@@ -59,10 +61,11 @@ describe('Render tests', () => {
         timeslots = { DEFAULT_TIMESLOTS }
         weekToRender = { weeks[0] }
         onTimeslotClick = { onClickSpy }
+        initialDate = { moment([2017, 1, 1]).format() }
       />
     );
 
-    const timeslot = component.find(Timeslot).first();
+    const timeslot = component.find(Timeslot).not('.tsc-timeslot--disabled').first();
     timeslot.simulate('click');
 
     expect(onClickSpy).toHaveProperty('callCount', 1);

--- a/__tests__/__snapshots__/Calendar.react-test.js.snap
+++ b/__tests__/__snapshots__/Calendar.react-test.js.snap
@@ -63,145 +63,145 @@ exports[`Render tests Renders Correctly. 1`] = `
           </span>
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           12:00 AM - 1:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           1:00 AM - 2:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           2:00 AM - 3:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           3:00 AM - 4:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           4:00 AM - 5:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           5:00 AM - 6:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           6:00 AM - 7:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           7:00 AM - 8:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           8:00 AM - 9:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           9:00 AM - 10:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           10:00 AM - 11:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           11:00 AM - 12:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           12:00 PM - 1:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           1:00 PM - 2:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           2:00 PM - 3:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           3:00 PM - 4:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           4:00 PM - 5:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           5:00 PM - 6:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           6:00 PM - 7:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           7:00 PM - 8:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           8:00 PM - 9:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           9:00 PM - 10:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           10:00 PM - 11:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           11:00 PM - 12:00 AM
@@ -218,145 +218,145 @@ exports[`Render tests Renders Correctly. 1`] = `
           </span>
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           12:00 AM - 1:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           1:00 AM - 2:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           2:00 AM - 3:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           3:00 AM - 4:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           4:00 AM - 5:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           5:00 AM - 6:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           6:00 AM - 7:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           7:00 AM - 8:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           8:00 AM - 9:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           9:00 AM - 10:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           10:00 AM - 11:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           11:00 AM - 12:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           12:00 PM - 1:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           1:00 PM - 2:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           2:00 PM - 3:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           3:00 PM - 4:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           4:00 PM - 5:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           5:00 PM - 6:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           6:00 PM - 7:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           7:00 PM - 8:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           8:00 PM - 9:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           9:00 PM - 10:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           10:00 PM - 11:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           11:00 PM - 12:00 AM
@@ -373,145 +373,145 @@ exports[`Render tests Renders Correctly. 1`] = `
           </span>
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           12:00 AM - 1:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           1:00 AM - 2:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           2:00 AM - 3:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           3:00 AM - 4:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           4:00 AM - 5:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           5:00 AM - 6:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           6:00 AM - 7:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           7:00 AM - 8:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           8:00 AM - 9:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           9:00 AM - 10:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           10:00 AM - 11:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           11:00 AM - 12:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           12:00 PM - 1:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           1:00 PM - 2:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           2:00 PM - 3:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           3:00 PM - 4:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           4:00 PM - 5:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           5:00 PM - 6:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           6:00 PM - 7:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           7:00 PM - 8:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           8:00 PM - 9:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           9:00 PM - 10:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           10:00 PM - 11:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           11:00 PM - 12:00 AM
@@ -528,145 +528,145 @@ exports[`Render tests Renders Correctly. 1`] = `
           </span>
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           12:00 AM - 1:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           1:00 AM - 2:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           2:00 AM - 3:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           3:00 AM - 4:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           4:00 AM - 5:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           5:00 AM - 6:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           6:00 AM - 7:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           7:00 AM - 8:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           8:00 AM - 9:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           9:00 AM - 10:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           10:00 AM - 11:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           11:00 AM - 12:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           12:00 PM - 1:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           1:00 PM - 2:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           2:00 PM - 3:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           3:00 PM - 4:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           4:00 PM - 5:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           5:00 PM - 6:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           6:00 PM - 7:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           7:00 PM - 8:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           8:00 PM - 9:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           9:00 PM - 10:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           10:00 PM - 11:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           11:00 PM - 12:00 AM
@@ -683,145 +683,145 @@ exports[`Render tests Renders Correctly. 1`] = `
           </span>
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           12:00 AM - 1:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           1:00 AM - 2:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           2:00 AM - 3:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           3:00 AM - 4:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           4:00 AM - 5:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           5:00 AM - 6:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           6:00 AM - 7:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           7:00 AM - 8:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           8:00 AM - 9:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           9:00 AM - 10:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           10:00 AM - 11:00 AM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           11:00 AM - 12:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           12:00 PM - 1:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           1:00 PM - 2:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           2:00 PM - 3:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           3:00 PM - 4:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           4:00 PM - 5:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           5:00 PM - 6:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           6:00 PM - 7:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           7:00 PM - 8:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           8:00 PM - 9:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           9:00 PM - 10:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           10:00 PM - 11:00 PM
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           11:00 PM - 12:00 AM
@@ -838,7 +838,7 @@ exports[`Render tests Renders Correctly. 1`] = `
           </span>
         </div>
         <div
-          className="tsc-timeslot"
+          className="tsc-timeslot tsc-timeslot--disabled"
           onClick={[Function]}
         >
           12:00 AM - 1:00 AM

--- a/__tests__/__snapshots__/Day.react-test.js.snap
+++ b/__tests__/__snapshots__/Day.react-test.js.snap
@@ -12,19 +12,19 @@ exports[`Render tests Renders Correctly if timeslots is an array of array. 1`] =
     </span>
   </div>
   <div
-    className="tsc-timeslot"
+    className="tsc-timeslot tsc-timeslot--disabled"
     onClick={[Function]}
   >
     Invalid date - Invalid date - Invalid date
   </div>
   <div
-    className="tsc-timeslot"
+    className="tsc-timeslot tsc-timeslot--disabled"
     onClick={[Function]}
   >
     Invalid date - Invalid date
   </div>
   <div
-    className="tsc-timeslot"
+    className="tsc-timeslot tsc-timeslot--disabled"
     onClick={[Function]}
   >
     Invalid date - Invalid date - Invalid date - Invalid date - Invalid date
@@ -44,19 +44,19 @@ exports[`Render tests Renders Correctly if timeslots is an array of strings. 1`]
     </span>
   </div>
   <div
-    className="tsc-timeslot"
+    className="tsc-timeslot tsc-timeslot--disabled"
     onClick={[Function]}
   >
     Invalid date - Invalid date - Invalid date
   </div>
   <div
-    className="tsc-timeslot"
+    className="tsc-timeslot tsc-timeslot--disabled"
     onClick={[Function]}
   >
     Invalid date - Invalid date - Invalid date - Invalid date
   </div>
   <div
-    className="tsc-timeslot"
+    className="tsc-timeslot tsc-timeslot--disabled"
     onClick={[Function]}
   >
     Invalid date - Invalid date - Invalid date - Invalid date - Invalid date
@@ -76,7 +76,7 @@ exports[`Render tests Renders Correctly with min props. 1`] = `
     </span>
   </div>
   <div
-    className="tsc-timeslot"
+    className="tsc-timeslot tsc-timeslot--disabled"
     onClick={[Function]}
   >
     12:00 AM - 1:00 AM

--- a/__tests__/__snapshots__/Day.react-test.js.snap
+++ b/__tests__/__snapshots__/Day.react-test.js.snap
@@ -15,19 +15,19 @@ exports[`Render tests Renders Correctly if timeslots is an array of array. 1`] =
     className="tsc-timeslot tsc-timeslot--disabled"
     onClick={[Function]}
   >
-    Invalid date - Invalid date - Invalid date
+    12:00 AM - 1:00 AM
   </div>
   <div
-    className="tsc-timeslot tsc-timeslot--disabled"
+    className="tsc-timeslot"
     onClick={[Function]}
   >
-    Invalid date - Invalid date
+    1:00 AM - 2:00 AM
   </div>
   <div
-    className="tsc-timeslot tsc-timeslot--disabled"
+    className="tsc-timeslot"
     onClick={[Function]}
   >
-    Invalid date - Invalid date - Invalid date - Invalid date - Invalid date
+    3:00 AM
   </div>
 </div>
 `;
@@ -47,19 +47,19 @@ exports[`Render tests Renders Correctly if timeslots is an array of strings. 1`]
     className="tsc-timeslot tsc-timeslot--disabled"
     onClick={[Function]}
   >
-    Invalid date - Invalid date - Invalid date
+    12:00 AM
   </div>
   <div
-    className="tsc-timeslot tsc-timeslot--disabled"
+    className="tsc-timeslot"
     onClick={[Function]}
   >
-    Invalid date - Invalid date - Invalid date - Invalid date
+    1:00 AM
   </div>
   <div
-    className="tsc-timeslot tsc-timeslot--disabled"
+    className="tsc-timeslot"
     onClick={[Function]}
   >
-    Invalid date - Invalid date - Invalid date - Invalid date - Invalid date
+    2:00 AM
   </div>
 </div>
 `;

--- a/__tests__/__snapshots__/Month.react-test.js.snap
+++ b/__tests__/__snapshots__/Month.react-test.js.snap
@@ -39,145 +39,145 @@ exports[`Render tests Renders Correctly with all props. 1`] = `
         </span>
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 AM - 1:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 AM - 2:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 AM - 3:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 AM - 4:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 AM - 5:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 AM - 6:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 AM - 7:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 AM - 8:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 AM - 9:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 AM - 10:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 AM - 11:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 AM - 12:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 PM - 1:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 PM - 2:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 PM - 3:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 PM - 4:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 PM - 5:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 PM - 6:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 PM - 7:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 PM - 8:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 PM - 9:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 PM - 10:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 PM - 11:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 PM - 12:00 AM
@@ -194,145 +194,145 @@ exports[`Render tests Renders Correctly with all props. 1`] = `
         </span>
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 AM - 1:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 AM - 2:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 AM - 3:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 AM - 4:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 AM - 5:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 AM - 6:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 AM - 7:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 AM - 8:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 AM - 9:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 AM - 10:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 AM - 11:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 AM - 12:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 PM - 1:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 PM - 2:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 PM - 3:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 PM - 4:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 PM - 5:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 PM - 6:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 PM - 7:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 PM - 8:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 PM - 9:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 PM - 10:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 PM - 11:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 PM - 12:00 AM
@@ -349,145 +349,145 @@ exports[`Render tests Renders Correctly with all props. 1`] = `
         </span>
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 AM - 1:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 AM - 2:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 AM - 3:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 AM - 4:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 AM - 5:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 AM - 6:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 AM - 7:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 AM - 8:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 AM - 9:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 AM - 10:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 AM - 11:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 AM - 12:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 PM - 1:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 PM - 2:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 PM - 3:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 PM - 4:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 PM - 5:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 PM - 6:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 PM - 7:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 PM - 8:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 PM - 9:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 PM - 10:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 PM - 11:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 PM - 12:00 AM
@@ -504,145 +504,145 @@ exports[`Render tests Renders Correctly with all props. 1`] = `
         </span>
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 AM - 1:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 AM - 2:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 AM - 3:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 AM - 4:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 AM - 5:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 AM - 6:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 AM - 7:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 AM - 8:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 AM - 9:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 AM - 10:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 AM - 11:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 AM - 12:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 PM - 1:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 PM - 2:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 PM - 3:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 PM - 4:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 PM - 5:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 PM - 6:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 PM - 7:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 PM - 8:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 PM - 9:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 PM - 10:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 PM - 11:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 PM - 12:00 AM
@@ -659,145 +659,145 @@ exports[`Render tests Renders Correctly with all props. 1`] = `
         </span>
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 AM - 1:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 AM - 2:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 AM - 3:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 AM - 4:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 AM - 5:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 AM - 6:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 AM - 7:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 AM - 8:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 AM - 9:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 AM - 10:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 AM - 11:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 AM - 12:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 PM - 1:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 PM - 2:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 PM - 3:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 PM - 4:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 PM - 5:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 PM - 6:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 PM - 7:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 PM - 8:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 PM - 9:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 PM - 10:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 PM - 11:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 PM - 12:00 AM
@@ -814,145 +814,145 @@ exports[`Render tests Renders Correctly with all props. 1`] = `
         </span>
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 AM - 1:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 AM - 2:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 AM - 3:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 AM - 4:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 AM - 5:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 AM - 6:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 AM - 7:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 AM - 8:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 AM - 9:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 AM - 10:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 AM - 11:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 AM - 12:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 PM - 1:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 PM - 2:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 PM - 3:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 PM - 4:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 PM - 5:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 PM - 6:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 PM - 7:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 PM - 8:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 PM - 9:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 PM - 10:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 PM - 11:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 PM - 12:00 AM
@@ -969,145 +969,145 @@ exports[`Render tests Renders Correctly with all props. 1`] = `
         </span>
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 AM - 1:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 AM - 2:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 AM - 3:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 AM - 4:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 AM - 5:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 AM - 6:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 AM - 7:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 AM - 8:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 AM - 9:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 AM - 10:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 AM - 11:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 AM - 12:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 PM - 1:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 PM - 2:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 PM - 3:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 PM - 4:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 PM - 5:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 PM - 6:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 PM - 7:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 PM - 8:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 PM - 9:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 PM - 10:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 PM - 11:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 PM - 12:00 AM
@@ -1156,145 +1156,145 @@ exports[`Render tests Renders Correctly with min props. 1`] = `
         </span>
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 AM - 1:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 AM - 2:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 AM - 3:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 AM - 4:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 AM - 5:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 AM - 6:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 AM - 7:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 AM - 8:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 AM - 9:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 AM - 10:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 AM - 11:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 AM - 12:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 PM - 1:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 PM - 2:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 PM - 3:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 PM - 4:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 PM - 5:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 PM - 6:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 PM - 7:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 PM - 8:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 PM - 9:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 PM - 10:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 PM - 11:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 PM - 12:00 AM
@@ -1311,145 +1311,145 @@ exports[`Render tests Renders Correctly with min props. 1`] = `
         </span>
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 AM - 1:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 AM - 2:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 AM - 3:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 AM - 4:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 AM - 5:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 AM - 6:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 AM - 7:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 AM - 8:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 AM - 9:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 AM - 10:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 AM - 11:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 AM - 12:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 PM - 1:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 PM - 2:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 PM - 3:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 PM - 4:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 PM - 5:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 PM - 6:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 PM - 7:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 PM - 8:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 PM - 9:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 PM - 10:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 PM - 11:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 PM - 12:00 AM
@@ -1466,145 +1466,145 @@ exports[`Render tests Renders Correctly with min props. 1`] = `
         </span>
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 AM - 1:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 AM - 2:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 AM - 3:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 AM - 4:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 AM - 5:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 AM - 6:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 AM - 7:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 AM - 8:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 AM - 9:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 AM - 10:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 AM - 11:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 AM - 12:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 PM - 1:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 PM - 2:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 PM - 3:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 PM - 4:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 PM - 5:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 PM - 6:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 PM - 7:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 PM - 8:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 PM - 9:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 PM - 10:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 PM - 11:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 PM - 12:00 AM
@@ -1621,145 +1621,145 @@ exports[`Render tests Renders Correctly with min props. 1`] = `
         </span>
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 AM - 1:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 AM - 2:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 AM - 3:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 AM - 4:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 AM - 5:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 AM - 6:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 AM - 7:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 AM - 8:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 AM - 9:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 AM - 10:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 AM - 11:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 AM - 12:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 PM - 1:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 PM - 2:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 PM - 3:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 PM - 4:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 PM - 5:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 PM - 6:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 PM - 7:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 PM - 8:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 PM - 9:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 PM - 10:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 PM - 11:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 PM - 12:00 AM
@@ -1776,145 +1776,145 @@ exports[`Render tests Renders Correctly with min props. 1`] = `
         </span>
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 AM - 1:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 AM - 2:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 AM - 3:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 AM - 4:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 AM - 5:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 AM - 6:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 AM - 7:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 AM - 8:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 AM - 9:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 AM - 10:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 AM - 11:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 AM - 12:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 PM - 1:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 PM - 2:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 PM - 3:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 PM - 4:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 PM - 5:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 PM - 6:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 PM - 7:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 PM - 8:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 PM - 9:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 PM - 10:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 PM - 11:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 PM - 12:00 AM
@@ -1931,145 +1931,145 @@ exports[`Render tests Renders Correctly with min props. 1`] = `
         </span>
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 AM - 1:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 AM - 2:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 AM - 3:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 AM - 4:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 AM - 5:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 AM - 6:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 AM - 7:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 AM - 8:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 AM - 9:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 AM - 10:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 AM - 11:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 AM - 12:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 PM - 1:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 PM - 2:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 PM - 3:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 PM - 4:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 PM - 5:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 PM - 6:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 PM - 7:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 PM - 8:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 PM - 9:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 PM - 10:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 PM - 11:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 PM - 12:00 AM
@@ -2086,145 +2086,145 @@ exports[`Render tests Renders Correctly with min props. 1`] = `
         </span>
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 AM - 1:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 AM - 2:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 AM - 3:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 AM - 4:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 AM - 5:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 AM - 6:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 AM - 7:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 AM - 8:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 AM - 9:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 AM - 10:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 AM - 11:00 AM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 AM - 12:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         12:00 PM - 1:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         1:00 PM - 2:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         2:00 PM - 3:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         3:00 PM - 4:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         4:00 PM - 5:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         5:00 PM - 6:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         6:00 PM - 7:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         7:00 PM - 8:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         8:00 PM - 9:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         9:00 PM - 10:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         10:00 PM - 11:00 PM
       </div>
       <div
-        className="tsc-timeslot"
+        className="tsc-timeslot tsc-timeslot--disabled"
         onClick={[Function]}
       >
         11:00 PM - 12:00 AM

--- a/__tests__/__snapshots__/Week.react-test.js.snap
+++ b/__tests__/__snapshots__/Week.react-test.js.snap
@@ -15,145 +15,145 @@ exports[`Render tests Renders Correctly with min props. 1`] = `
       </span>
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       12:00 AM - 1:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       1:00 AM - 2:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       2:00 AM - 3:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       3:00 AM - 4:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       4:00 AM - 5:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       5:00 AM - 6:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       6:00 AM - 7:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       7:00 AM - 8:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       8:00 AM - 9:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       9:00 AM - 10:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       10:00 AM - 11:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       11:00 AM - 12:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       12:00 PM - 1:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       1:00 PM - 2:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       2:00 PM - 3:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       3:00 PM - 4:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       4:00 PM - 5:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       5:00 PM - 6:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       6:00 PM - 7:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       7:00 PM - 8:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       8:00 PM - 9:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       9:00 PM - 10:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       10:00 PM - 11:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       11:00 PM - 12:00 AM
@@ -170,145 +170,145 @@ exports[`Render tests Renders Correctly with min props. 1`] = `
       </span>
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       12:00 AM - 1:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       1:00 AM - 2:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       2:00 AM - 3:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       3:00 AM - 4:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       4:00 AM - 5:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       5:00 AM - 6:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       6:00 AM - 7:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       7:00 AM - 8:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       8:00 AM - 9:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       9:00 AM - 10:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       10:00 AM - 11:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       11:00 AM - 12:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       12:00 PM - 1:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       1:00 PM - 2:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       2:00 PM - 3:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       3:00 PM - 4:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       4:00 PM - 5:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       5:00 PM - 6:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       6:00 PM - 7:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       7:00 PM - 8:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       8:00 PM - 9:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       9:00 PM - 10:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       10:00 PM - 11:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       11:00 PM - 12:00 AM
@@ -325,145 +325,145 @@ exports[`Render tests Renders Correctly with min props. 1`] = `
       </span>
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       12:00 AM - 1:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       1:00 AM - 2:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       2:00 AM - 3:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       3:00 AM - 4:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       4:00 AM - 5:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       5:00 AM - 6:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       6:00 AM - 7:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       7:00 AM - 8:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       8:00 AM - 9:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       9:00 AM - 10:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       10:00 AM - 11:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       11:00 AM - 12:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       12:00 PM - 1:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       1:00 PM - 2:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       2:00 PM - 3:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       3:00 PM - 4:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       4:00 PM - 5:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       5:00 PM - 6:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       6:00 PM - 7:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       7:00 PM - 8:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       8:00 PM - 9:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       9:00 PM - 10:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       10:00 PM - 11:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       11:00 PM - 12:00 AM
@@ -480,145 +480,145 @@ exports[`Render tests Renders Correctly with min props. 1`] = `
       </span>
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       12:00 AM - 1:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       1:00 AM - 2:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       2:00 AM - 3:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       3:00 AM - 4:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       4:00 AM - 5:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       5:00 AM - 6:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       6:00 AM - 7:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       7:00 AM - 8:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       8:00 AM - 9:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       9:00 AM - 10:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       10:00 AM - 11:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       11:00 AM - 12:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       12:00 PM - 1:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       1:00 PM - 2:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       2:00 PM - 3:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       3:00 PM - 4:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       4:00 PM - 5:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       5:00 PM - 6:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       6:00 PM - 7:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       7:00 PM - 8:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       8:00 PM - 9:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       9:00 PM - 10:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       10:00 PM - 11:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       11:00 PM - 12:00 AM
@@ -635,145 +635,145 @@ exports[`Render tests Renders Correctly with min props. 1`] = `
       </span>
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       12:00 AM - 1:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       1:00 AM - 2:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       2:00 AM - 3:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       3:00 AM - 4:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       4:00 AM - 5:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       5:00 AM - 6:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       6:00 AM - 7:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       7:00 AM - 8:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       8:00 AM - 9:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       9:00 AM - 10:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       10:00 AM - 11:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       11:00 AM - 12:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       12:00 PM - 1:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       1:00 PM - 2:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       2:00 PM - 3:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       3:00 PM - 4:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       4:00 PM - 5:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       5:00 PM - 6:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       6:00 PM - 7:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       7:00 PM - 8:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       8:00 PM - 9:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       9:00 PM - 10:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       10:00 PM - 11:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       11:00 PM - 12:00 AM
@@ -790,145 +790,145 @@ exports[`Render tests Renders Correctly with min props. 1`] = `
       </span>
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       12:00 AM - 1:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       1:00 AM - 2:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       2:00 AM - 3:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       3:00 AM - 4:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       4:00 AM - 5:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       5:00 AM - 6:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       6:00 AM - 7:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       7:00 AM - 8:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       8:00 AM - 9:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       9:00 AM - 10:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       10:00 AM - 11:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       11:00 AM - 12:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       12:00 PM - 1:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       1:00 PM - 2:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       2:00 PM - 3:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       3:00 PM - 4:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       4:00 PM - 5:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       5:00 PM - 6:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       6:00 PM - 7:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       7:00 PM - 8:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       8:00 PM - 9:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       9:00 PM - 10:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       10:00 PM - 11:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       11:00 PM - 12:00 AM
@@ -945,145 +945,145 @@ exports[`Render tests Renders Correctly with min props. 1`] = `
       </span>
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       12:00 AM - 1:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       1:00 AM - 2:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       2:00 AM - 3:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       3:00 AM - 4:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       4:00 AM - 5:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       5:00 AM - 6:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       6:00 AM - 7:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       7:00 AM - 8:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       8:00 AM - 9:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       9:00 AM - 10:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       10:00 AM - 11:00 AM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       11:00 AM - 12:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       12:00 PM - 1:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       1:00 PM - 2:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       2:00 PM - 3:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       3:00 PM - 4:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       4:00 PM - 5:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       5:00 PM - 6:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       6:00 PM - 7:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       7:00 PM - 8:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       8:00 PM - 9:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       9:00 PM - 10:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       10:00 PM - 11:00 PM
     </div>
     <div
-      className="tsc-timeslot"
+      className="tsc-timeslot tsc-timeslot--disabled"
       onClick={[Function]}
     >
       11:00 PM - 12:00 AM

--- a/src/js/components/calendar.jsx
+++ b/src/js/components/calendar.jsx
@@ -52,6 +52,7 @@ export default class Calendar extends React.Component {
 
     const {
       timeslots,
+      initialDate,
     } = this.props;
 
     const cal = new CalendarJS(currentDate.year(), currentDate.month() + 1);
@@ -60,6 +61,7 @@ export default class Calendar extends React.Component {
     return (
       <Month
         currentDate = { currentDate }
+        initialDate = { initialDate }
         weeks = { weeks }
         onWeekOutOfMonth = { this._onWeekOutOfMonth.bind(this) }
         onTimeslotSelected = { this._onTimeslotSelected.bind(this) }

--- a/src/js/components/calendar.jsx
+++ b/src/js/components/calendar.jsx
@@ -61,7 +61,7 @@ export default class Calendar extends React.Component {
     return (
       <Month
         currentDate = { currentDate }
-        initialDate = { initialDate }
+        initialDate = { moment(initialDate) }
         weeks = { weeks }
         onWeekOutOfMonth = { this._onWeekOutOfMonth.bind(this) }
         onTimeslotSelected = { this._onTimeslotSelected.bind(this) }
@@ -83,7 +83,7 @@ export default class Calendar extends React.Component {
       currentDate,
     } = this.state;
 
-    let nextDate = currentDate
+    let nextDate = currentDate.clone()
       .startOf('month')
       .add(1, 'months')
       .startOf('month');
@@ -98,7 +98,7 @@ export default class Calendar extends React.Component {
       currentDate,
     } = this.state;
 
-    let nextDate = currentDate
+    let nextDate = currentDate.clone()
       .startOf('month')
       .subtract(1, 'months')
       .startOf('month');

--- a/src/js/components/day.jsx
+++ b/src/js/components/day.jsx
@@ -9,6 +9,11 @@ import {
   DEFAULT_TIMESLOT_SHOW_FORMAT,
 } from '../constants/day.js';
 
+import {
+  DEFAULT,
+  DISABLED,
+} from '../constants/timeslot.js';
+
 export default class Day extends React.Component {
 
   render() {
@@ -39,9 +44,11 @@ export default class Day extends React.Component {
 
   _renderTimeSlots() {
     const {
+      timeslots,
       timeslotFormat,
       timeslotShowFormat,
-      timeslots,
+      momentTime,
+      initialDate,
     } = this.props;
 
     return timeslots.map((slot, index) => {
@@ -52,11 +59,15 @@ export default class Day extends React.Component {
           description += ' - ';
         }
       }
+      let timeslotDate = momentTime.clone();
+      let status = moment(initialDate).isBefore(timeslotDate.add(slot[0], timeslotFormat)) ? DEFAULT : DISABLED;
+
       return (
         <Timeslot
           key = { index }
           description = { description }
           onClick = { this._onTimeslotClick.bind(this, index) }
+          status = { status }
         />
       );
     });
@@ -88,10 +99,11 @@ Day.defaultProps = {
  * @type {Object} momentTime: MomentJS datetime object.
  */
 Day.propTypes = {
+  timeslots: PropTypes.array.isRequired,
   timeslotFormat: PropTypes.string.isRequired,
   timeslotShowFormat: PropTypes.string.isRequired,
-  timeslots: PropTypes.array.isRequired,
   onTimeslotClick: PropTypes.func.isRequired,
   renderTitle: PropTypes.func.isRequired,
   momentTime: PropTypes.object.isRequired,
+  initialDate: PropTypes.string.isRequired,
 };

--- a/src/js/components/day.jsx
+++ b/src/js/components/day.jsx
@@ -60,7 +60,13 @@ export default class Day extends React.Component {
         }
       }
       let timeslotDate = momentTime.clone();
-      let status = moment(initialDate).isBefore(timeslotDate.add(slot[0], timeslotFormat)) ? DEFAULT : DISABLED;
+      timeslotDate.add(slot[0], timeslotFormat);
+
+      let status = DEFAULT;
+      if (timeslotDate.isBefore(initialDate) || timeslotDate.isSame(initialDate)) {
+        status = DISABLED;
+      }
+
 
       return (
         <Timeslot
@@ -105,5 +111,5 @@ Day.propTypes = {
   onTimeslotClick: PropTypes.func.isRequired,
   renderTitle: PropTypes.func.isRequired,
   momentTime: PropTypes.object.isRequired,
-  initialDate: PropTypes.string.isRequired,
+  initialDate: PropTypes.object.isRequired,
 };

--- a/src/js/components/month.jsx
+++ b/src/js/components/month.jsx
@@ -110,7 +110,7 @@ export default class Month extends React.Component {
       });
     }
     else if (onWeekOutOfMonth) {
-      const firstDayOfPrevWeek = helpers.getMomentFromCalendarJSDateElement(weeks[0][0]).subtract(1, 'days');
+      const firstDayOfPrevWeek = helpers.getMomentFromCalendarJSDateElement(weeks[0][0]).clone().subtract(1, 'days');
       onWeekOutOfMonth(firstDayOfPrevWeek);
     }
   }
@@ -135,7 +135,7 @@ export default class Month extends React.Component {
     }
     else if (onWeekOutOfMonth) {
       const lastDay = weeks[currentWeekIndex].length - 1;
-      const firstDayOfNextWeek = helpers.getMomentFromCalendarJSDateElement(weeks[currentWeekIndex][lastDay]).add(1, 'days');
+      const firstDayOfNextWeek = helpers.getMomentFromCalendarJSDateElement(weeks[currentWeekIndex][lastDay]).clone().add(1, 'days');
       onWeekOutOfMonth(firstDayOfNextWeek);
     }
   }
@@ -157,6 +157,6 @@ Month.propTypes = {
   currentDate: PropTypes.object.isRequired,
   weeks: PropTypes.array.isRequired,
   onWeekOutOfMonth: PropTypes.func,
-  initialDate: PropTypes.string.isRequired,
+  initialDate: PropTypes.object.isRequired,
   timeslots : PropTypes.array.isRequired,
 };

--- a/src/js/components/month.jsx
+++ b/src/js/components/month.jsx
@@ -77,6 +77,7 @@ export default class Month extends React.Component {
 
     const {
       weeks,
+      initialDate,
       timeslots,
     } = this.props;
 
@@ -84,6 +85,7 @@ export default class Month extends React.Component {
       <Week
         weekToRender = { weeks[currentWeekIndex] }
         onTimeslotClick = { () => {} }
+        initialDate = { initialDate }
         timeslots = { timeslots }
       />
     );
@@ -155,5 +157,6 @@ Month.propTypes = {
   currentDate: PropTypes.object.isRequired,
   weeks: PropTypes.array.isRequired,
   onWeekOutOfMonth: PropTypes.func,
+  initialDate: PropTypes.string.isRequired,
   timeslots : PropTypes.array.isRequired,
 };

--- a/src/js/components/week.jsx
+++ b/src/js/components/week.jsx
@@ -50,6 +50,6 @@ export default class Week extends React.Component {
 Week.propTypes = {
   weekToRender: PropTypes.array.isRequired,
   onTimeslotClick: PropTypes.func.isRequired,
-  initialDate: PropTypes.string.isRequired,
+  initialDate: PropTypes.object.isRequired,
   timeslots : PropTypes.array.isRequired,
 };

--- a/src/js/components/week.jsx
+++ b/src/js/components/week.jsx
@@ -16,6 +16,7 @@ export default class Week extends React.Component {
   _renderWeekDays() {
     const {
       weekToRender,
+      initialDate,
       timeslots,
     } = this.props;
 
@@ -25,8 +26,9 @@ export default class Week extends React.Component {
         <Day
           key = { index }
           onTimeslotClick = { this._onTimeslotClick.bind(this, index) }
-          momentTime = { formattedDate }
+          initialDate = { initialDate }
           timeslots = { timeslots }
+          momentTime = { formattedDate }
           />
       );
     });
@@ -48,5 +50,6 @@ export default class Week extends React.Component {
 Week.propTypes = {
   weekToRender: PropTypes.array.isRequired,
   onTimeslotClick: PropTypes.func.isRequired,
+  initialDate: PropTypes.string.isRequired,
   timeslots : PropTypes.array.isRequired,
 };


### PR DESCRIPTION
- Added disabled status to time slots previous to the initialized date sent over from Calendar
- Setup the *initialDate* to travel all through the tree in order to reach Day and disable respective timeslots.
- Added a new test to verify that disabling timeslots is working as intended. 
- Fixed up other tests and snapshots in order to work with the new **initialDate**. This makes it so that snapshots have all the *disabled* status, since the date used (Apr 28, 2017) is already long gone. Could be set up to 2099 in order to avoid this. Open to suggestions.