### PR TITLE
Add ability to send disabled timeslots as props.

### DIFF
--- a/__tests__/Calendar.react-test.js
+++ b/__tests__/Calendar.react-test.js
@@ -106,4 +106,34 @@ describe('Render tests', () => {
 
     expect(inputs).toHaveLength(4);
   });
+
+  test('Expects 3 disabled timeslots based on props sent.', () => {
+    const component = mount(
+      <Calendar
+        initialDate = { moment([2017, 3, 30]).format() }
+        timeslots = { DEFAULT_TIMESLOTS }
+        disabledTimeslots = { [
+          {
+            startDate: 'April 30th 2017, 12:00:00 AM',
+            endDate: 'April 30th 2017, 1:00:00 AM',
+            format: 'MMMM Do YYYY, h:mm:ss A',
+          },
+          {
+            startDate: 'May 1st 2017, 3:00:00 PM',
+            endDate: 'May 1st 2017, 4:00:00 PM',
+            format: 'MMMM Do YYYY, h:mm:ss A',
+          },
+          {
+            startDate: 'May 5th 2017, 6:00:00 PM',
+            endDate: 'May 5th 2017, 7:00:00 PM',
+            format: 'MMMM Do YYYY, h:mm:ss A',
+          },
+        ] }
+      />
+    );
+
+    const disabledTimeslots = component.findWhere(timeslot => timeslot.prop('status') == 'DISABLED');
+
+    expect(disabledTimeslots).toHaveLength(3);
+  });
 });

--- a/__tests__/Day.react-test.js
+++ b/__tests__/Day.react-test.js
@@ -8,7 +8,11 @@ import {
 } from 'enzyme';
 import Day from '../src/js/components/day';
 import Timeslot from '../src/js/components/timeslot';
-import { DEFAULT_TIMESLOTS } from '../src/js/constants/day';
+import {
+  DEFAULT_TIMESLOTS,
+  DEFAULT_TIMESLOT_FORMAT,
+  DEFAULT_TIMESLOT_SHOW_FORMAT,
+} from '../src/js/constants/day';
 
 describe('Render tests', () => {
   test('Renders Correctly with min props.', () => {
@@ -16,6 +20,11 @@ describe('Render tests', () => {
     const tree = renderer.create(
       <Day
         timeslots = { DEFAULT_TIMESLOTS }
+        timeslotProps = { {
+          format: DEFAULT_TIMESLOT_FORMAT,
+          showFormat:DEFAULT_TIMESLOT_SHOW_FORMAT,
+        } }
+        disabledTimeslots = { [] }
         onTimeslotClick = { onClickSpy }
         momentTime = { moment([2017, 3, 28]) }
         initialDate = { moment([2017, 3, 28]) }
@@ -38,6 +47,11 @@ describe('Render tests', () => {
     const tree = renderer.create(
       <Day
         timeslots = { timeslots }
+        timeslotProps = { {
+          format: DEFAULT_TIMESLOT_FORMAT,
+          showFormat:DEFAULT_TIMESLOT_SHOW_FORMAT,
+        } }
+        disabledTimeslots = { [] }
         onTimeslotClick = { onClickSpy }
         momentTime = { moment([2017, 3, 28]) }
         initialDate = { moment([2017, 3, 28]) }
@@ -60,6 +74,11 @@ describe('Render tests', () => {
     const tree = renderer.create(
       <Day
       timeslots = { timeslots }
+      timeslotProps = { {
+        format: DEFAULT_TIMESLOT_FORMAT,
+        showFormat:DEFAULT_TIMESLOT_SHOW_FORMAT,
+      } }
+      disabledTimeslots = { [] }
       onTimeslotClick = { onClickSpy }
       momentTime = { moment([2017, 3, 28]) }
       initialDate = { moment([2017, 3, 28]) }
@@ -79,6 +98,11 @@ describe('Functionality tests', () => {
     const component = mount(
       <Day
         timeslots = { DEFAULT_TIMESLOTS }
+        timeslotProps = { {
+          format: DEFAULT_TIMESLOT_FORMAT,
+          showFormat:DEFAULT_TIMESLOT_SHOW_FORMAT,
+        } }
+        disabledTimeslots = { [] }
         onTimeslotClick = { onClickSpy }
         renderTitle = { renderTitleSpy }
         momentTime = { moment([2017, 3, 28]) }
@@ -95,6 +119,11 @@ describe('Functionality tests', () => {
     const component = mount(
       <Day
         timeslots = { DEFAULT_TIMESLOTS }
+        timeslotProps = { {
+          format: DEFAULT_TIMESLOT_FORMAT,
+          showFormat:DEFAULT_TIMESLOT_SHOW_FORMAT,
+        } }
+        disabledTimeslots = { [] }
         onTimeslotClick = { onClickSpy }
         momentTime = { moment([2017, 3, 28]) }
         initialDate = { moment([2017, 3, 27]) }
@@ -113,6 +142,11 @@ describe('Functionality tests', () => {
     const component = shallow(
       <Day
         timeslots = { DEFAULT_TIMESLOTS }
+        timeslotProps = { {
+          format: DEFAULT_TIMESLOT_FORMAT,
+          showFormat:DEFAULT_TIMESLOT_SHOW_FORMAT,
+        } }
+        disabledTimeslots = { [] }
         onTimeslotClick = { onClickSpy }
         momentTime = { moment([2017, 3, 28]) }
         initialDate = { moment([2017, 1, 1]) }
@@ -134,6 +168,11 @@ describe('Functionality tests', () => {
     const component = shallow(
       <Day
         timeslots = { timeslots }
+        timeslotProps = { {
+          format: DEFAULT_TIMESLOT_FORMAT,
+          showFormat:DEFAULT_TIMESLOT_SHOW_FORMAT,
+        } }
+        disabledTimeslots = { [] }
         onTimeslotClick = { onClickSpy }
         momentTime = { moment([2017, 3, 28]) }
         initialDate = { moment([2017, 3, 28]) }
@@ -151,6 +190,11 @@ describe('Functionality tests', () => {
     const component = mount(
       <Day
         timeslots = { DEFAULT_TIMESLOTS }
+        timeslotProps = { {
+          format: DEFAULT_TIMESLOT_FORMAT,
+          showFormat:DEFAULT_TIMESLOT_SHOW_FORMAT,
+        } }
+        disabledTimeslots = { [] }
         onTimeslotClick = { onClickSpy }
         momentTime = { moment([2017, 3, 28]) }
         initialDate = { moment([2017, 3, 28, 11]) }

--- a/__tests__/Month.react-test.js
+++ b/__tests__/Month.react-test.js
@@ -8,7 +8,11 @@ import {
 } from 'enzyme';
 import Month from '../src/js/components/month';
 import helpers from '../src/js/util/helpers';
-import { DEFAULT_TIMESLOTS } from '../src/js/constants/day';
+import {
+  DEFAULT_TIMESLOTS,
+  DEFAULT_TIMESLOT_FORMAT,
+  DEFAULT_TIMESLOT_SHOW_FORMAT,
+ } from '../src/js/constants/day';
 
 const cal = new Calendar(2017, 4);
 
@@ -18,6 +22,11 @@ describe('Render tests', () => {
     const tree = renderer.create(
       <Month
         timeslots = { DEFAULT_TIMESLOTS }
+        timeslotProps = { {
+          format: DEFAULT_TIMESLOT_FORMAT,
+          showFormat:DEFAULT_TIMESLOT_SHOW_FORMAT,
+        } }
+        disabledTimeslots = { [] }
         weeks = { weeks }
         currentDate = { moment([2017, 3, 1]) }
         initialDate = { moment([2017, 3, 28]) }
@@ -35,6 +44,11 @@ describe('Render tests', () => {
     const tree = renderer.create(
       <Month
         timeslots = { DEFAULT_TIMESLOTS }
+        timeslotProps = { {
+          format: DEFAULT_TIMESLOT_FORMAT,
+          showFormat:DEFAULT_TIMESLOT_SHOW_FORMAT,
+        } }
+        disabledTimeslots = { [] }
         weeks = { weeks }
         currentDate = { moment([2017, 3, 1]) }
         initialDate = { moment([2017, 3, 28]) }
@@ -55,6 +69,11 @@ describe('Functionality tests', () => {
     const component = mount(
       <Month
         timeslots = { DEFAULT_TIMESLOTS }
+        timeslotProps = { {
+          format: DEFAULT_TIMESLOT_FORMAT,
+          showFormat:DEFAULT_TIMESLOT_SHOW_FORMAT,
+        } }
+        disabledTimeslots = { [] }
         weeks = { weeks }
         currentDate = { currentDate }
         initialDate = { moment([2017, 3, 28]) }
@@ -85,6 +104,11 @@ describe('Functionality tests', () => {
     const component = mount(
       <Month
         timeslots = { DEFAULT_TIMESLOTS }
+        timeslotProps = { {
+          format: DEFAULT_TIMESLOT_FORMAT,
+          showFormat:DEFAULT_TIMESLOT_SHOW_FORMAT,
+        } }
+        disabledTimeslots = { [] }
         weeks = { weeks }
         currentDate = { currentDate }
         initialDate = { moment([2017, 3, 28]) }
@@ -104,6 +128,11 @@ describe('Functionality tests', () => {
     const component = mount(
       <Month
         timeslots = { DEFAULT_TIMESLOTS }
+        timeslotProps = { {
+          format: DEFAULT_TIMESLOT_FORMAT,
+          showFormat:DEFAULT_TIMESLOT_SHOW_FORMAT,
+        } }
+        disabledTimeslots = { [] }
         weeks = { weeks }
         currentDate = { currentDate }
         initialDate = { moment([2017, 3, 28]) }
@@ -122,6 +151,11 @@ describe('Functionality tests', () => {
     const component = mount(
       <Month
         timeslots = { DEFAULT_TIMESLOTS }
+        timeslotProps = { {
+          format: DEFAULT_TIMESLOT_FORMAT,
+          showFormat:DEFAULT_TIMESLOT_SHOW_FORMAT,
+        } }
+        disabledTimeslots = { [] }
         weeks = { weeks }
         currentDate = { currentDate }
         initialDate = { moment([2017, 3, 28]) }
@@ -140,6 +174,11 @@ describe('Functionality tests', () => {
     const component = mount(
       <Month
         timeslots = { DEFAULT_TIMESLOTS }
+        timeslotProps = { {
+          format: DEFAULT_TIMESLOT_FORMAT,
+          showFormat:DEFAULT_TIMESLOT_SHOW_FORMAT,
+        } }
+        disabledTimeslots = { [] }
         weeks = { weeks }
         currentDate = { currentDate }
         initialDate = { moment([2017, 3, 28]) }

--- a/__tests__/Week.react-test.js
+++ b/__tests__/Week.react-test.js
@@ -12,7 +12,11 @@ import Week from '../src/js/components/week';
 import Day from '../src/js/components/day';
 import Timeslot from '../src/js/components/timeslot';
 
-import { DEFAULT_TIMESLOTS } from '../src/js/constants/day';
+import {
+  DEFAULT_TIMESLOTS,
+  DEFAULT_TIMESLOT_FORMAT,
+  DEFAULT_TIMESLOT_SHOW_FORMAT,
+} from '../src/js/constants/day';
 
 const cal = new Calendar(2017, 4);
 
@@ -24,6 +28,11 @@ describe('Render tests', () => {
     const tree = renderer.create(
       <Week
         timeslots = { DEFAULT_TIMESLOTS }
+        timeslotProps = { {
+          format: DEFAULT_TIMESLOT_FORMAT,
+          showFormat:DEFAULT_TIMESLOT_SHOW_FORMAT,
+        } }
+        disabledTimeslots = { [] }
         weekToRender = { weeks[0] }
         onTimeslotClick = { onClickSpy }
         initialDate = { moment([2017, 3, 28]) }
@@ -42,6 +51,11 @@ describe('Render tests', () => {
     const component = mount(
       <Week
         timeslots = { DEFAULT_TIMESLOTS }
+        timeslotProps = { {
+          format: DEFAULT_TIMESLOT_FORMAT,
+          showFormat:DEFAULT_TIMESLOT_SHOW_FORMAT,
+        } }
+        disabledTimeslots = { [] }
         weekToRender = { weeks[0].slice(0, 3) }
         onTimeslotClick = { onClickSpy }
         initialDate = { moment([2017, 3, 28]) }
@@ -61,6 +75,11 @@ describe('Render tests', () => {
     const component = mount(
       <Week
         timeslots = { DEFAULT_TIMESLOTS }
+        timeslotProps = { {
+          format: DEFAULT_TIMESLOT_FORMAT,
+          showFormat:DEFAULT_TIMESLOT_SHOW_FORMAT,
+        } }
+        disabledTimeslots = { [] }
         weekToRender = { weeks[0] }
         onTimeslotClick = { onClickSpy }
         initialDate = { moment([2017, 1, 1]) }

--- a/src/js/components/calendar.jsx
+++ b/src/js/components/calendar.jsx
@@ -221,13 +221,37 @@ export default class Calendar extends React.Component {
     });
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.inputProps = {
-      startDate: Object.assign({}, this.inputProps.startDateInputProps, nextProps.startDateInputProps),
-      endDate: Object.assign({}, this.inputProps.endDateInputProps, nextProps.endDateInputProps),
+  _updateInputProps(startDateInputProps, endDateInputProps) {
+    const defaultStartDateProps = {
+      name: 'tsc-startDate',
+      classes: 'tsc-hidden-input',
+      type: 'hidden',
     };
 
-    this.timeslotProps = Object.assign({}, this.timeslotProps, nextProps.timeslotProps);
+    const defaultEndDateProps = {
+      name: 'tsc-endDate',
+      classes: 'tsc-hidden-input',
+      type: 'hidden',
+    };
+
+    this.inputProps = {
+      startDate: Object.assign({}, defaultStartDateProps, startDateInputProps),
+      endDate: Object.assign({}, defaultEndDateProps, endDateInputProps),
+    };
+  }
+
+  _updateTimeslotProps(timeslotProps) {
+    const defaultProps = {
+      format: 'h',
+      showFormat: 'h:mm A',
+    };
+
+    this.timeslotProps = Object.assign({}, defaultProps, timeslotProps);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this._updateInputProps(nextProps.startDateInputProps, nextProps.endDateInputProps);
+    this._updateTimeslotProps(nextProps.timeslotProps);
   }
 
 }

--- a/src/js/components/calendar.jsx
+++ b/src/js/components/calendar.jsx
@@ -7,31 +7,10 @@ import Month from './month.jsx';
 export default class Calendar extends React.Component {
   constructor(props) {
 
-    const startDateInputProps = {
-      name: 'tsc-startDate',
-      classes: 'tsc-hidden-input',
-      type: 'hidden',
-    };
-
-    const endDateInputProps = {
-      name: 'tsc-endDate',
-      class: 'tsc-hidden-input',
-      type: 'hidden',
-    };
-
-    const timeslotProps = {
-      format: 'h',
-      showFormat: 'h:mm A',
-    };
-
     super(props);
 
-    this.inputProps = {
-      startDate: Object.assign({}, startDateInputProps, this.props.startDateInputProps),
-      endDate: Object.assign({}, endDateInputProps, this.props.endDateInputProps),
-    };
-
-    this.timeslotProps = Object.assign({}, timeslotProps, this.props.timeslotProps);
+    this._updateInputProps(this.props.startDateInputProps, this.props.endDateInputProps);
+    this._updateTimeslotProps(this.props.timeslotProps);
 
     this.state = {
       currentDate: moment(props.initialDate),

--- a/src/js/components/calendar.jsx
+++ b/src/js/components/calendar.jsx
@@ -99,7 +99,6 @@ export default class Calendar extends React.Component {
         timeslotProps = { this.timeslotProps }
         selectedTimeslots = { selectedTimeslots }
         disabledTimeslots = { this._formatDisabledTimeslots() }
-
       />
     );
   }
@@ -220,6 +219,15 @@ export default class Calendar extends React.Component {
     this.setState({
       selectedTimeslots: newSelectedTimeslots,
     });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.inputProps = {
+      startDate: Object.assign({}, this.inputProps.startDateInputProps, nextProps.startDateInputProps),
+      endDate: Object.assign({}, this.inputProps.endDateInputProps, nextProps.endDateInputProps),
+    };
+
+    this.timeslotProps = Object.assign({}, this.timeslotProps, nextProps.timeslotProps);
   }
 
 }

--- a/src/js/components/calendar.jsx
+++ b/src/js/components/calendar.jsx
@@ -19,12 +19,19 @@ export default class Calendar extends React.Component {
       type: 'hidden',
     };
 
+    const timeslotProps = {
+      format: 'h',
+      showFormat: 'h:mm A',
+    };
+
     super(props);
 
     this.inputProps = {
       startDate: Object.assign({}, startDateInputProps, this.props.startDateInputProps),
       endDate: Object.assign({}, endDateInputProps, this.props.endDateInputProps),
     };
+
+    this.timeslotProps = Object.assign({}, timeslotProps, this.props.timeslotProps);
 
     this.state = {
       currentDate: moment(props.initialDate),
@@ -89,7 +96,10 @@ export default class Calendar extends React.Component {
         onWeekOutOfMonth = { this._onWeekOutOfMonth.bind(this) }
         onTimeslotClick = { this._onTimeslotClick.bind(this) }
         timeslots = { timeslots }
+        timeslotProps = { this.timeslotProps }
         selectedTimeslots = { selectedTimeslots }
+        disabledTimeslots = { this._formatDisabledTimeslots() }
+
       />
     );
   }
@@ -165,6 +175,20 @@ export default class Calendar extends React.Component {
     });
   }
 
+  _formatDisabledTimeslots() {
+    const {
+      disabledTimeslots,
+    } = this.props;
+
+    return disabledTimeslots.map((timeslot) => {
+      let timeslotMoment = Object.assign({}, timeslot);
+      timeslotMoment.startDate = moment(timeslotMoment.startDate, timeslotMoment.format);
+      timeslotMoment.endDate = moment(timeslotMoment.endDate, timeslotMoment.format);
+
+      return timeslotMoment;
+    });
+  }
+
   _onTimeslotClick(newTimeslot) {
     const {
       selectedTimeslots,
@@ -201,6 +225,7 @@ export default class Calendar extends React.Component {
 }
 
 Calendar.defaultProps = {
+  disabledTimeslots: [],
   maxTimeslots: 1,
   inputProps: {
     names: {},
@@ -212,7 +237,9 @@ Calendar.defaultProps = {
 /**
  * @type {String} initialDate:  The initial date in which to place the calendar. Must be MomentJS parseable.
  * @type {Array} timeslots:  An array of timeslots to be displayed in each day.
- * @type {string} selectedTimeslot: Initial value for timeslot input.
+ * @type {Object} timeslotProps: An object with keys and values for timeslot props (format, viewFormat)
+ * @type {Array} selectedTimeslots: Initial value for selected timeslot inputs. Expects Dates formatted as Strings.
+ * @type {Array} disabledTimeslots: Initial value for selected timeslot inputs. Expects Dates formatted as Strings.
  * @type {Integer} maxTimexlots: maximum ammount of timeslots to select.
  * @type {Object} startDateInputProps: properties for the startDate Inputs. Includes name, class, type (hidden, text...)
  * @type {Object} endDateInputProps: properties for the endDate Inputs. Includes name, class, type (hidden, text...)
@@ -220,7 +247,9 @@ Calendar.defaultProps = {
 Calendar.propTypes = {
   initialDate: PropTypes.string.isRequired,
   timeslots: PropTypes.array.isRequired,
-  selectedTimeslots: PropTypes.string,
+  timeslotProps: PropTypes.object,
+  selectedTimeslots: PropTypes.array,
+  disabledTimeslots: PropTypes.array,
   maxTimeslots: PropTypes.number,
   inputProps: PropTypes.object,
   startDateInputProps: PropTypes.object,

--- a/src/js/components/day.jsx
+++ b/src/js/components/day.jsx
@@ -46,9 +46,9 @@ export default class Day extends React.Component {
   _renderTimeSlots() {
     const {
       timeslots,
+      timeslotProps,
       selectedTimeslots,
-      timeslotFormat,
-      timeslotShowFormat,
+      disabledTimeslots,
       momentTime,
       initialDate,
     } = this.props;
@@ -56,13 +56,13 @@ export default class Day extends React.Component {
     return timeslots.map((slot, index) => {
       let description = '';
       for (let i = 0; i < slot.length; i ++){
-        description += moment(slot[i], timeslotFormat).format(timeslotShowFormat);
+        description += moment(slot[i], timeslotProps.format).format(timeslotProps.showFormat);
         if (i < (slot.length - 1)){
           description += ' - ';
         }
       }
       let timeslotDate = momentTime.clone();
-      timeslotDate.add(slot[0], timeslotFormat);
+      timeslotDate.add(slot[0], timeslotProps.format);
 
       let status = DEFAULT;
       if (timeslotDate.isBefore(initialDate) || timeslotDate.isSame(initialDate)) {
@@ -73,7 +73,14 @@ export default class Day extends React.Component {
         return timeslotDate.format() === selectedTimeslot.startDate.format();
       });
 
-      if (isSelected) {
+      const isDisabled = disabledTimeslots.some((disabledTimeslot) => {
+        return timeslotDate.format() === disabledTimeslot.startDate.format();
+      });
+
+      if (isDisabled) {
+        status = DISABLED;
+      }
+      else if (isSelected) {
         status = SELECTED;
       }
 
@@ -116,7 +123,9 @@ Day.defaultProps = {
 
 /**
  * @type {Array} timeslots: Array of timeslots.
- * @type {Array} selectedTimslots: Selected Timeslots Set used to add the SELECTED class if needed when renderizing timeslots.
+ * @type {Object} timeslotProps: An object with keys and values for timeslot props (format, viewFormat)
+ * @type {Array} selectedTimeslots: Selected Timeslots Set used to add the SELECTED status if needed when renderizing timeslots.
+ * @type {Array} disabledTimeslots: Disabled Timeslots Set used to add the DISABLED status if needed when renderizing timeslots.
  * @type {String} timeslotFormat: format used by moment when identifying the timeslot
  * @type {String} timslotShowFormat: format to show used by moment when formating timeslot hours for final view.
  * @type {Function} onTimeslotClick: Function to be excecuted when clicked.
@@ -126,7 +135,9 @@ Day.defaultProps = {
  */
 Day.propTypes = {
   timeslots: PropTypes.array.isRequired,
+  timeslotProps: PropTypes.object,
   selectedTimeslots: PropTypes.array,
+  disabledTimeslots: PropTypes.array,
   timeslotFormat: PropTypes.string.isRequired,
   timeslotShowFormat: PropTypes.string.isRequired,
   onTimeslotClick: PropTypes.func.isRequired,

--- a/src/js/components/month.jsx
+++ b/src/js/components/month.jsx
@@ -79,7 +79,9 @@ export default class Month extends React.Component {
       weeks,
       initialDate,
       timeslots,
+      timeslotProps,
       selectedTimeslots,
+      disabledTimeslots,
     } = this.props;
 
     return (
@@ -88,7 +90,9 @@ export default class Month extends React.Component {
         onTimeslotClick = { this._onTimeslotClick.bind(this) }
         initialDate = { initialDate }
         timeslots = { timeslots }
+        timeslotProps = { timeslotProps }
         selectedTimeslots = { selectedTimeslots }
+        disabledTimeslots = { disabledTimeslots }
       />
     );
   }
@@ -164,7 +168,9 @@ export default class Month extends React.Component {
 * @type {Function} onTimeslotClick: Function to be excecuted when clicked.
 * @type {Object} initialDate: Moment JS Date used to initialize the Calendar and which progresses further into the tree.
 * @type {Array} timeslots: An array of timeslots to be displayed in each day.
+* @type {Object} timeslotProps: An object with keys and values for timeslot props (format, viewFormat)
 * @type {Array} selectedTimeslots: Selected Timeslots Set used further into the tree to add the classes needed to when renderizing timeslots.
+* @type {Array} DisabledTimeslots: Disabled Timeslots Set used further into the tree to add the classes needed to when renderizing timeslots.
  */
 Month.propTypes = {
   currentDate: PropTypes.object.isRequired,
@@ -172,6 +178,8 @@ Month.propTypes = {
   onWeekOutOfMonth: PropTypes.func,
   onTimeslotClick: PropTypes.func,
   initialDate: PropTypes.object.isRequired,
-  timeslots : PropTypes.array.isRequired,
+  timeslots: PropTypes.array.isRequired,
+  timeslotProps: PropTypes.object,
   selectedTimeslots: PropTypes.array,
+  disabledTimeslots: PropTypes.array,
 };

--- a/src/js/components/week.jsx
+++ b/src/js/components/week.jsx
@@ -18,7 +18,9 @@ export default class Week extends React.Component {
       weekToRender,
       initialDate,
       timeslots,
+      timeslotProps,
       selectedTimeslots,
+      disabledTimeslots,
     } = this.props;
 
     return weekToRender.map((day, index) => {
@@ -29,7 +31,9 @@ export default class Week extends React.Component {
           onTimeslotClick = { this._onTimeslotClick.bind(this) }
           initialDate = { initialDate }
           timeslots = { timeslots }
+          timeslotProps = { timeslotProps }
           selectedTimeslots = { selectedTimeslots }
+          disabledTimeslots = { disabledTimeslots }
           momentTime = { formattedDate }
           />
       );
@@ -50,12 +54,16 @@ export default class Week extends React.Component {
  * @type {Function} onTimeslotClick: Function to be excecuted when clicked.
  * @type {Object} initialDate: Moment JS Date used to initialize the Calendar and which progresses further into the tree.
  * @type {Array} timeslots: Timeslots Set of Timeslot elements to render. Progresses further into the tree.
+ * @type {Object} timeslotProps: An object with keys and values for timeslot props (format, viewFormat)
  * @type {Array} selectedTimeslots: Selected Timeslots Set used further into the tree to add the classes needed to when renderizing timeslots.
+ * @type {Array} disabledTimeslots: Disabled Timeslots Set used further into the tree to add the classes needed to when renderizing timeslots.
  */
 Week.propTypes = {
   weekToRender: PropTypes.array.isRequired,
   onTimeslotClick: PropTypes.func.isRequired,
   initialDate: PropTypes.object.isRequired,
   timeslots : PropTypes.array.isRequired,
+  timeslotProps: PropTypes.object,
   selectedTimeslots: PropTypes.array,
+  disabledTimeslots: PropTypes.array,
 };

--- a/src/js/react-timeslot-calendar.jsx
+++ b/src/js/react-timeslot-calendar.jsx
@@ -23,18 +23,24 @@ ReactTimeslotCalendar.defaultProps = {
   timeslots: DEFAULT_TIMESLOTS,
 };
 
+/// A PEDIR -> Chicken Pockets + Smoothie (Fresa / Kiwi / Pinia)
+
 /**
  * @type {String} initialDate:  The initial date in which to place the calendar. Must be MomentJS parseable.
  * @type {Array} timeslots:  An array of timeslots to be displayed in each day.
- * @type {string} selectedTimeslot: Initial value for timeslot input.
+ * @type {Object} timeslotProps: An object with keys and values for timeslot props (format, viewFormat)
+ * @type {Array} selectedTimeslots: Initial value for selected timeslot inputs. Expects Dates formatted as Strings.
+ * @type {Array} disabledTimeslots: Initial value for selected timeslot inputs. Expects: StartDate, EndDate, Format.
  * @type {Integer} maxTimexlots: maximum ammount of timeslots to select.
  * @type {Object} startDateInputProps: properties for the startDate Inputs. Includes name, class, type (hidden, text...)
  * @type {Object} endDateInputProps: properties for the endDate Inputs. Includes name, class, type (hidden, text...)
  */
-ReactTimeslotCalendar.propTypes = {
+Calendar.propTypes = {
   initialDate: PropTypes.string.isRequired,
   timeslots: PropTypes.array.isRequired,
-  selectedTimeslots: PropTypes.string,
+  timeslotProps: PropTypes.object,
+  selectedTimeslots: PropTypes.array,
+  disabledTimeslots: PropTypes.array,
   maxTimeslots: PropTypes.number,
   inputProps: PropTypes.object,
   startDateInputProps: PropTypes.object,

--- a/src/js/react-timeslot-calendar.jsx
+++ b/src/js/react-timeslot-calendar.jsx
@@ -23,7 +23,6 @@ ReactTimeslotCalendar.defaultProps = {
   timeslots: DEFAULT_TIMESLOTS,
 };
 
-/// A PEDIR -> Chicken Pockets + Smoothie (Fresa / Kiwi / Pinia)
 
 /**
  * @type {String} initialDate:  The initial date in which to place the calendar. Must be MomentJS parseable.
@@ -35,7 +34,7 @@ ReactTimeslotCalendar.defaultProps = {
  * @type {Object} startDateInputProps: properties for the startDate Inputs. Includes name, class, type (hidden, text...)
  * @type {Object} endDateInputProps: properties for the endDate Inputs. Includes name, class, type (hidden, text...)
  */
-Calendar.propTypes = {
+ReactTimeslotCalendar.propTypes = {
   initialDate: PropTypes.string.isRequired,
   timeslots: PropTypes.array.isRequired,
   timeslotProps: PropTypes.object,


### PR DESCRIPTION
- Added ability to send a prop (disabledTimeslots) which contains timeslot objects with **startDate**, **endDate**, and **Format**, so that the users can choose how to send each timeslot.
- Added ability to send a prop (timeslotProps), which contains the **format** of the timeslots (hours, days, minutes...) and the **showFormat**, how the timeslot data will show.
- Added test to verify that everything is working correctly with disabled timeslots.
- Fixed old tests in order to properly work with the new changes (meaning, sending a disabledTimeslot & timeslotProps props all the way down when Calendar does not send it because the tests are being made on a lower level.)