### PR TITLE
Add ability to send which days to render (or not). Add test to verify…

### DIFF
--- a/__tests__/Month.react-test.js
+++ b/__tests__/Month.react-test.js
@@ -8,6 +8,8 @@ import {
 } from 'enzyme';
 import Month from '../src/js/components/month';
 import helpers from '../src/js/util/helpers';
+
+import { RENDER_DAYS } from '../src/js/constants/week';
 import {
   DEFAULT_TIMESLOTS,
   DEFAULT_TIMESLOT_FORMAT,
@@ -31,6 +33,7 @@ describe('Render tests', () => {
         currentDate = { moment([2017, 3, 1]) }
         initialDate = { moment([2017, 3, 28]) }
         selectedTimeslots = { [] }
+        renderDays = { RENDER_DAYS }
       />
     )
     .toJSON();
@@ -54,6 +57,7 @@ describe('Render tests', () => {
         initialDate = { moment([2017, 3, 28]) }
         onWeekOutOfMonth = { onWeekOutOfMonth }
         selectedTimeslots = { [] }
+        renderDays = { RENDER_DAYS }
       />
     )
     .toJSON();
@@ -78,6 +82,7 @@ describe('Functionality tests', () => {
         currentDate = { currentDate }
         initialDate = { moment([2017, 3, 28]) }
         selectedTimeslots = { [] }
+        renderDays = { RENDER_DAYS }
       />
     );
 
@@ -114,6 +119,7 @@ describe('Functionality tests', () => {
         initialDate = { moment([2017, 3, 28]) }
         onWeekOutOfMonth = { onWeekOutOfMonth }
         selectedTimeslots = { [] }
+        renderDays = { RENDER_DAYS }
       />
     );
 
@@ -138,6 +144,7 @@ describe('Functionality tests', () => {
         initialDate = { moment([2017, 3, 28]) }
         onWeekOutOfMonth = { onWeekOutOfMonth }
         selectedTimeslots = { [] }
+        renderDays = { RENDER_DAYS }
       />
     );
 
@@ -160,6 +167,7 @@ describe('Functionality tests', () => {
         currentDate = { currentDate }
         initialDate = { moment([2017, 3, 28]) }
         selectedTimeslots = { [] }
+        renderDays = { RENDER_DAYS }
       />
     );
     const weekIndexBeforeClick = component.state().currentWeekIndex;
@@ -183,6 +191,7 @@ describe('Functionality tests', () => {
         currentDate = { currentDate }
         initialDate = { moment([2017, 3, 28]) }
         selectedTimeslots = { [] }
+        renderDays = { RENDER_DAYS }
       />
     );
 

--- a/__tests__/Week.react-test.js
+++ b/__tests__/Week.react-test.js
@@ -12,6 +12,7 @@ import Week from '../src/js/components/week';
 import Day from '../src/js/components/day';
 import Timeslot from '../src/js/components/timeslot';
 
+import { RENDER_DAYS } from '../src/js/constants/week';
 import {
   DEFAULT_TIMESLOTS,
   DEFAULT_TIMESLOT_FORMAT,
@@ -37,6 +38,7 @@ describe('Render tests', () => {
         onTimeslotClick = { onClickSpy }
         initialDate = { moment([2017, 3, 28]) }
         selectedTimeslots = { [] }
+        renderDays = { RENDER_DAYS }
       />
     )
     .toJSON();
@@ -60,6 +62,7 @@ describe('Render tests', () => {
         onTimeslotClick = { onClickSpy }
         initialDate = { moment([2017, 3, 28]) }
         selectedTimeslots = { [] }
+        renderDays = { RENDER_DAYS }
       />
     );
 
@@ -84,6 +87,7 @@ describe('Render tests', () => {
         onTimeslotClick = { onClickSpy }
         initialDate = { moment([2017, 1, 1]) }
         selectedTimeslots = { [] }
+        renderDays = { RENDER_DAYS }
       />
     );
 
@@ -91,5 +95,37 @@ describe('Render tests', () => {
     timeslot.simulate('click');
 
     expect(onClickSpy).toHaveProperty('callCount', 1);
+  });
+
+  test('Week Renders only 3 Days when specifying days to render.', () => {
+    const onClickSpy = sinon.spy();
+    const weeks = cal.generate();
+
+    const component = mount(
+      <Week
+        timeslots = { DEFAULT_TIMESLOTS }
+        timeslotProps = { {
+          format: DEFAULT_TIMESLOT_FORMAT,
+          showFormat:DEFAULT_TIMESLOT_SHOW_FORMAT,
+        } }
+        disabledTimeslots = { [] }
+        weekToRender = { weeks[0] }
+        onTimeslotClick = { onClickSpy }
+        initialDate = { moment([2017, 1, 1]) }
+        selectedTimeslots = { [] }
+        renderDays = { {
+          sunday: false,
+          monday: false,
+          tuesday: true,
+          wednesday: true,
+          thursday: true,
+          friday: false,
+          saturday: false,
+        } }
+      />
+    );
+
+    const days = component.find(Day);
+    expect(days).toHaveLength(3);
   });
 });

--- a/src/js/components/calendar.jsx
+++ b/src/js/components/calendar.jsx
@@ -247,6 +247,7 @@ export default class Calendar extends React.Component {
   componentWillReceiveProps(nextProps) {
     this._updateInputProps(nextProps.startDateInputProps, nextProps.endDateInputProps);
     this._updateTimeslotProps(nextProps.timeslotProps);
+    this._updateRenderDays(nextProps.renderDays);
   }
 
 }

--- a/src/js/components/calendar.jsx
+++ b/src/js/components/calendar.jsx
@@ -11,6 +11,7 @@ export default class Calendar extends React.Component {
 
     this._updateInputProps(this.props.startDateInputProps, this.props.endDateInputProps);
     this._updateTimeslotProps(this.props.timeslotProps);
+    this._updateRenderDays(this.props.renderDays);
 
     this.state = {
       currentDate: moment(props.initialDate),
@@ -78,6 +79,7 @@ export default class Calendar extends React.Component {
         timeslotProps = { this.timeslotProps }
         selectedTimeslots = { selectedTimeslots }
         disabledTimeslots = { this._formatDisabledTimeslots() }
+        renderDays = { this.renderDays }
       />
     );
   }
@@ -228,6 +230,20 @@ export default class Calendar extends React.Component {
     this.timeslotProps = Object.assign({}, defaultProps, timeslotProps);
   }
 
+  _updateRenderDays(renderDays) {
+    const defaultRenderDays = {
+      sunday: true,
+      monday: true,
+      tuesday: true,
+      wednesday: true,
+      thursday: true,
+      friday: true,
+      saturday: true,
+    };
+
+    this.renderDays = Object.assign({}, defaultRenderDays, renderDays);
+  }
+
   componentWillReceiveProps(nextProps) {
     this._updateInputProps(nextProps.startDateInputProps, nextProps.endDateInputProps);
     this._updateTimeslotProps(nextProps.timeslotProps);
@@ -252,6 +268,7 @@ Calendar.defaultProps = {
  * @type {Array} selectedTimeslots: Initial value for selected timeslot inputs. Expects Dates formatted as Strings.
  * @type {Array} disabledTimeslots: Initial value for selected timeslot inputs. Expects Dates formatted as Strings.
  * @type {Integer} maxTimexlots: maximum ammount of timeslots to select.
+ * @type {Object} renderDays: An array of days which states which days of the week to render. By default renders all days.
  * @type {Object} startDateInputProps: properties for the startDate Inputs. Includes name, class, type (hidden, text...)
  * @type {Object} endDateInputProps: properties for the endDate Inputs. Includes name, class, type (hidden, text...)
  */
@@ -262,7 +279,7 @@ Calendar.propTypes = {
   selectedTimeslots: PropTypes.array,
   disabledTimeslots: PropTypes.array,
   maxTimeslots: PropTypes.number,
-  inputProps: PropTypes.object,
+  renderDays: PropTypes.object,
   startDateInputProps: PropTypes.object,
   endDateInputProps: PropTypes.object,
 };

--- a/src/js/components/month.jsx
+++ b/src/js/components/month.jsx
@@ -82,6 +82,7 @@ export default class Month extends React.Component {
       timeslotProps,
       selectedTimeslots,
       disabledTimeslots,
+      renderDays,
     } = this.props;
 
     return (
@@ -93,6 +94,7 @@ export default class Month extends React.Component {
         timeslotProps = { timeslotProps }
         selectedTimeslots = { selectedTimeslots }
         disabledTimeslots = { disabledTimeslots }
+        renderDays = { renderDays }
       />
     );
   }
@@ -171,6 +173,7 @@ export default class Month extends React.Component {
 * @type {Object} timeslotProps: An object with keys and values for timeslot props (format, viewFormat)
 * @type {Array} selectedTimeslots: Selected Timeslots Set used further into the tree to add the classes needed to when renderizing timeslots.
 * @type {Array} DisabledTimeslots: Disabled Timeslots Set used further into the tree to add the classes needed to when renderizing timeslots.
+* @type {Object} renderDays: An array of days which states which days of the week to render. By default renders all days.
  */
 Month.propTypes = {
   currentDate: PropTypes.object.isRequired,
@@ -182,4 +185,5 @@ Month.propTypes = {
   timeslotProps: PropTypes.object,
   selectedTimeslots: PropTypes.array,
   disabledTimeslots: PropTypes.array,
+  renderDays: PropTypes.object,
 };

--- a/src/js/components/week.jsx
+++ b/src/js/components/week.jsx
@@ -26,7 +26,8 @@ export default class Week extends React.Component {
 
     return weekToRender.map((day, index) => {
       let formattedDate = helpers.getMomentFromCalendarJSDateElement(day);
-      if (renderDays[formattedDate.format('dddd').toLowerCase()]){
+      const weekDay = formattedDate.format('dddd').toLowerCase();
+      if (renderDays[weekDay]){
         return (
           <Day
             key = { index }

--- a/src/js/components/week.jsx
+++ b/src/js/components/week.jsx
@@ -21,22 +21,25 @@ export default class Week extends React.Component {
       timeslotProps,
       selectedTimeslots,
       disabledTimeslots,
+      renderDays,
     } = this.props;
 
     return weekToRender.map((day, index) => {
       let formattedDate = helpers.getMomentFromCalendarJSDateElement(day);
-      return (
-        <Day
-          key = { index }
-          onTimeslotClick = { this._onTimeslotClick.bind(this) }
-          initialDate = { initialDate }
-          timeslots = { timeslots }
-          timeslotProps = { timeslotProps }
-          selectedTimeslots = { selectedTimeslots }
-          disabledTimeslots = { disabledTimeslots }
-          momentTime = { formattedDate }
-          />
-      );
+      if (renderDays[formattedDate.format('dddd').toLowerCase()]){
+        return (
+          <Day
+            key = { index }
+            onTimeslotClick = { this._onTimeslotClick.bind(this) }
+            initialDate = { initialDate }
+            timeslots = { timeslots }
+            timeslotProps = { timeslotProps }
+            selectedTimeslots = { selectedTimeslots }
+            disabledTimeslots = { disabledTimeslots }
+            momentTime = { formattedDate }
+            />
+        );
+      }
     });
   }
 
@@ -57,6 +60,7 @@ export default class Week extends React.Component {
  * @type {Object} timeslotProps: An object with keys and values for timeslot props (format, viewFormat)
  * @type {Array} selectedTimeslots: Selected Timeslots Set used further into the tree to add the classes needed to when renderizing timeslots.
  * @type {Array} disabledTimeslots: Disabled Timeslots Set used further into the tree to add the classes needed to when renderizing timeslots.
+ * @type {Object} renderDays: An array of days which states which days of the week to render. By default renders all days.
  */
 Week.propTypes = {
   weekToRender: PropTypes.array.isRequired,
@@ -66,4 +70,5 @@ Week.propTypes = {
   timeslotProps: PropTypes.object,
   selectedTimeslots: PropTypes.array,
   disabledTimeslots: PropTypes.array,
+  renderDays: PropTypes.object,
 };

--- a/src/js/constants/week.js
+++ b/src/js/constants/week.js
@@ -1,0 +1,9 @@
+export const RENDER_DAYS = {
+  sunday: true,
+  monday: true,
+  tuesday: true,
+  wednesday: true,
+  thursday: true,
+  friday: true,
+  saturday: true,
+};

--- a/src/js/demo/app.jsx
+++ b/src/js/demo/app.jsx
@@ -13,6 +13,10 @@ export default class App extends React.Component {
         React Timeslot Calendar!
         <ReactTimeslotCalendar
           initialDate = { moment().format() }
+          renderDays = { {
+            sunday: false,
+            saturday: false,
+          } }
         />
       </div>
     );

--- a/src/js/react-timeslot-calendar.jsx
+++ b/src/js/react-timeslot-calendar.jsx
@@ -31,6 +31,7 @@ ReactTimeslotCalendar.defaultProps = {
  * @type {Array} selectedTimeslots: Initial value for selected timeslot inputs. Expects Dates formatted as Strings.
  * @type {Array} disabledTimeslots: Initial value for selected timeslot inputs. Expects: StartDate, EndDate, Format.
  * @type {Integer} maxTimexlots: maximum ammount of timeslots to select.
+ * @type {Object} renderDays: An array of days which states which days of the week to render. By default renders all days.
  * @type {Object} startDateInputProps: properties for the startDate Inputs. Includes name, class, type (hidden, text...)
  * @type {Object} endDateInputProps: properties for the endDate Inputs. Includes name, class, type (hidden, text...)
  */
@@ -41,7 +42,7 @@ ReactTimeslotCalendar.propTypes = {
   selectedTimeslots: PropTypes.array,
   disabledTimeslots: PropTypes.array,
   maxTimeslots: PropTypes.number,
-  inputProps: PropTypes.object,
+  renderDays: PropTypes.object,
   startDateInputProps: PropTypes.object,
   endDateInputProps: PropTypes.object,
 };


### PR DESCRIPTION
- Added ability to send an prop object with week days (**renderDays**) and select which of them should be rendered. 
- Added a new test which sends the renderDays prop and tests if the amount of days rendered match the requested amount.
- Fixed previous tests to reflect the current changes.