### PR TITLE
Use UNSAFE_componentWillReceiveProps

### DIFF
--- a/src/js/components/calendar.jsx
+++ b/src/js/components/calendar.jsx
@@ -246,7 +246,8 @@ export default class Calendar extends React.Component {
     this.renderDays = Object.assign({}, defaultRenderDays, renderDays);
   }
 
-  componentWillReceiveProps(nextProps) {
+  // eslint-disable-next-line
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this._updateInputProps(nextProps.startDateInputProps, nextProps.endDateInputProps);
     this._updateTimeslotProps(nextProps.timeslotProps);
     this._updateRenderDays(nextProps.renderDays);

--- a/src/js/components/month.jsx
+++ b/src/js/components/month.jsx
@@ -155,8 +155,8 @@ export default class Month extends React.Component {
       onWeekOutOfMonth(firstDayOfNextWeek);
     }
   }
-
-  componentWillReceiveProps(nextProps) {
+  // eslint-disable-next-line
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState({
       currentWeekIndex: this._getStartingWeek(nextProps.currentDate, nextProps.weeks),
     });


### PR DESCRIPTION
Fix error thrown by npm, `componentWillReceiveProps` is deprecated since `React 16.3.0`

<img width="847" alt="screen shot 2018-11-02 at 2 48 45 pm" src="https://user-images.githubusercontent.com/6419886/47918519-76e58400-deb5-11e8-907d-8e7d9657e0ae.png">
